### PR TITLE
support rollup 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,10 @@ module.exports = function browsersync(options) {
 
     return {
         name: 'browsersync',
-        onwrite: function(bundle) {
-            bs.reload(bundle.dest);
+        generateBundle: function({}, bundle, isWrite) {
+            if (isWrite) {
+                bs.reload(bundle.dest);
+            }
         }
     }
 };


### PR DESCRIPTION
Really dig this plugin, thanks! The newer version of rollup has deprecated `onwrite` in favor of `generateBundle` which carries a slightly different signature, but results in the same thing in this case. So I just made a quick update if you like.