### PR TITLE
fix: await bundle finish before open browser url to prevent a 404 page

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,20 @@
 var bs = require('browser-sync').create('rollup');
 
 module.exports = function browsersync(options) {
-    if (!bs.active) {
-        bs.init(options || {server: '.'});
-    }
-
     return {
         name: 'browsersync',
-        generateBundle: function({}, bundle, isWrite) {
-            if (isWrite) {
-                bs.reload(bundle.dest);
-            }
+        writeBundle() {
+            new Promise((resolve) => {
+                /**
+                 * Only open the browser when the entire bundle
+                 * process is complete and the files are saved.
+                 */
+                if (!bs.active) {
+                    bs.init(options || { server: '.' })
+                }
+
+                resolve()
+            })
         }
     }
 };


### PR DESCRIPTION
This PR's fix the 404 page in the first view of the application.
